### PR TITLE
The url to go to the openGL project has been moved

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,6 @@
 Go bindings for GLUT: https://github.com/rhencke/Go-GLUT
 
-Requires: https://github.com/banthar/Go-OpenGL
+Requires: https://github.com/banthar/gl
 
 When installing Go-OpenGL, please use:
     gomake install


### PR DESCRIPTION
Updating the README to show the new url.
