### PR TITLE
Fix go-gl/gl import

### DIFF
--- a/glut.go
+++ b/glut.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 	"unsafe"
 
-	"github.com/go-gl/gl"
+	"github.com/go-gl/gl/v3.3-core/gl"
 )
 
 // #cgo darwin  LDFLAGS: -framework GLUT

--- a/glut.go
+++ b/glut.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 	"unsafe"
 
-	"github.com/go-gl/gl/v3.3-core/gl"
+	"github.com/go-gl/gl/v4.5-core/gl"
 )
 
 // #cgo darwin  LDFLAGS: -framework GLUT


### PR DESCRIPTION
According to go-gl/gl [github repo](https://github.com/go-gl/gl), imports have taken the shape of 
```
"github.com/go-gl/gl/v{3.2,3.3,4.1,4.4,4.5}-{core,compatibility}/gl"
```
Just fixing that in the project.